### PR TITLE
disable the Rock's bundle implementation

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -1,0 +1,3 @@
+base_scripts = Autoproj.manifest.find_autobuild_package('base/scripts')
+Autoproj.env.remove_path 'ROBY_PLUGIN_PATH', File.join(base_scripts.srcdir, 'lib', 'rock', 'roby_plugin.rb')
+


### PR DESCRIPTION
It is a horrible hack that outlived its usefulness in a Rock&Syskit
scenario. It interferes with Roby's loading mechanisms in
unpredictable and uncontrollable ways, so disable it.