### PR TITLE
override syskit_use_bundles to disable using rock/bundle in syskit

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,0 +1,2 @@
+Autoproj.config.set 'syskit_use_bundles', false, true
+

--- a/overrides.rb
+++ b/overrides.rb
@@ -1,3 +1,0 @@
-base_scripts = Autoproj.manifest.find_autobuild_package('base/scripts')
-Autoproj.env.remove_path 'ROBY_PLUGIN_PATH', File.join(base_scripts.srcdir, 'lib', 'rock', 'roby_plugin.rb')
-


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/package_set/pull/160