### PR TITLE
make the dependency of simulation/rock_gazebo on the gazebo_fixup_pkgconfig package optional

### DIFF
--- a/gazebo.autobuild
+++ b/gazebo.autobuild
@@ -53,7 +53,7 @@ end
 
 orogen_package "simulation/orogen/rock_gazebo"
 cmake_package "simulation/rock_gazebo" do |pkg|
-    pkg.depends_on "simulation/gazebo_pkgconfig_fixup"
+    pkg.optional_dependency "simulation/gazebo_pkgconfig_fixup"
     if Autoproj.manifest.excluded?('simulation/gazebo')
         pkg.define 'BUILD_GAZEBO_PLUGIN', 'OFF'
     end


### PR DESCRIPTION
gazebo is an optional dependency of this package because of the self-contained syskit support for using SDF. Need to make gazebo_fixup_pkgconfig optional as well for the same reasons.