### PR TITLE
chore: explicitly pass the path to bundles/common_models to simulation/rock_gazebo test suite

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -1,0 +1,13 @@
+setup_package "simulation/rock_gazebo" do |pkg|
+    # Tests in bindings/ruby (which are the only tests of this package) are
+    # handled by rock.core/overrides.rb. This leads to having to do this setup
+    # in here as well, instead of the normal place
+
+    pkg.post_import do
+        if pkg.test_utility.enabled?
+            pkg.env_set "ROCK_GAZEBO_TESTS_COMMON_MODELS_PATH",
+                        Autoproj.manifest.find_autobuild_package("bundles/common_models").srcdir
+        end
+    end
+end
+    


### PR DESCRIPTION
The current implementation of the test suite resolved the path using rock's bundle, which is deprecated from our (Syskit-user) perspective, and is incompatible with runkit.